### PR TITLE
Update the vllm command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ By default, Proxy Lite will point to an endpoint set up on HuggingFace spaces.
 We recommend hosting your own endpoint with vLLM, you can use the following command:
 
 ```bash
-vllm serve --model convergence-ai/proxy-lite-3b \
+vllm serve convergence-ai/proxy-lite-3b \
     --trust-remote-code \
     --enable-auto-tool-choice \
     --tool-call-parser hermes \


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change modifies the command for hosting your own endpoint with vLLM by removing the unnecessary `--model` flag. 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R90): Updated the vLLM command to remove the `--model` flag for vllm>=0.7.2.