### PR TITLE
feat(webbrowser): add `storage_state` support to reuse authenticated Playwright sessions

### DIFF
--- a/src/proxy_lite/browser/browser.py
+++ b/src/proxy_lite/browser/browser.py
@@ -90,7 +90,7 @@ class BrowserSession:
         self.playwright: Playwright | None = None
         self.browser: Browser | None = None
         self.context: BrowserContext | None = None
-        
+        self.storage_state = storage_state
         self._exit_stack: AsyncExitStack | None = None
 
         self.poi_elements: list = Field(default_factory=list)

--- a/src/proxy_lite/browser/browser.py
+++ b/src/proxy_lite/browser/browser.py
@@ -82,6 +82,7 @@ class BrowserSession:
         viewport_width: int = 1280,
         viewport_height: int = 720,
         headless: bool = True,
+        storage_state: Optional[str] = None,
     ):
         self.viewport_width = viewport_width
         self.viewport_height = viewport_height
@@ -89,6 +90,7 @@ class BrowserSession:
         self.playwright: Playwright | None = None
         self.browser: Browser | None = None
         self.context: BrowserContext | None = None
+        
         self._exit_stack: AsyncExitStack | None = None
 
         self.poi_elements: list = Field(default_factory=list)
@@ -103,6 +105,7 @@ class BrowserSession:
         self.browser = await self.playwright.chromium.launch(headless=self.headless)
         self.context = await self.browser.new_context(
             viewport={"width": self.viewport_width, "height": self.viewport_height},
+            storage_state=self.storage_state,
         )
         await self.context.new_page()
         self.context.set_default_timeout(60_000)

--- a/src/proxy_lite/environments/webbrowser.py
+++ b/src/proxy_lite/environments/webbrowser.py
@@ -2,6 +2,8 @@ import base64
 from functools import cached_property
 from typing import Any, Literal, Optional, Self
 
+from pydantic import Field
+
 from proxy_lite.browser.browser import BrowserSession
 from proxy_lite.environments.environment_base import (
     Action,
@@ -28,6 +30,7 @@ class WebBrowserEnvironmentConfig(BaseEnvironmentConfig):
     browserbase_timeout: int = 7200
     headless: bool = True
     keep_original_image: bool = False
+    storage_state: Optional[str] = Field(default=None, description="Path to a file containing cookies and other browser storage state.")
     no_pois_in_image: bool = False
 
 
@@ -46,6 +49,7 @@ class WebBrowserEnvironment(BaseEnvironment):
             viewport_width=self.config.viewport_width,
             viewport_height=self.config.viewport_height,
             headless=self.config.headless,
+            storage_state=self.config.storage_state,
         )
         await self.browser.__aenter__()
         # Initialize other resources if necessary


### PR DESCRIPTION
This PR lets proxy-lite load an existing Playwright storage_state file (cookies + local/sessionStorage) so agents can start from an already-authenticated context instead of repeating the login flow.

Example:
```
from proxy_lite import Runner, RunnerConfig

cfg = RunnerConfig.from_dict({
    "environment": {
        "name": "webbrowser",
        "homepage": "https://www.giponext.it/Agende/Classic",
        "headless": False,
        # NEW: point to the JSON produced by playwright.storage_state()
        "storage_state": "/abs/path/to/state.json",
    },
    "solver": {
        "name": "simple",
        "agent": {
            "name": "proxy_lite",
            "client": { "name": "convergence" }
        },
    },
})
runner = Runner(config=cfg)
```