### PR TITLE
feat(clients):add GPT-4.1 tool-call support

### DIFF
--- a/src/proxy_lite/agents/agent_base.py
+++ b/src/proxy_lite/agents/agent_base.py
@@ -28,7 +28,9 @@ from proxy_lite.tools import Tool
 
 class BaseAgentConfig(BaseModel):
     client: ClientConfigTypes = Field(default_factory=OpenAIClientConfig)
-    history_messages_limit: dict[MessageLabel, int] = Field(default_factory=lambda: dict())
+    history_messages_limit: dict[MessageLabel, int] = Field(
+        default_factory=lambda: dict()
+    )
     history_messages_include: Optional[dict[MessageLabel, int]] = Field(
         default=None,
         description="If set, overrides history_messages_limit by setting all message types to 0 except those specified",
@@ -73,7 +75,9 @@ class BaseAgent(BaseModel, ABC):
     def tool_descriptions(self) -> str:
         tool_descriptions = []
         for tool in self.tools:
-            func_descriptions = "\n".join("- {name}: {description}".format(**schema) for schema in tool.schema)
+            func_descriptions = "\n".join(
+                "- {name}: {description}".format(**schema) for schema in tool.schema
+            )
             tool_title = f"{tool.__class__.__name__}:\n" if len(self.tools) > 1 else ""
             tool_descriptions.append(f"{tool_title}{func_descriptions}")
         return "\n\n".join(tool_descriptions)
@@ -108,9 +112,21 @@ class BaseAgent(BaseModel, ABC):
             )
         ).model_dump()
         response_content = response_content["choices"][0]["message"]
+        # Re‑inject tool_calls as text blocks so legacy parser keeps working
+        tool_blocks = ""
+        if response_content["tool_calls"]:
+            import json, uuid
+
+            tool_blocks = "\n".join(
+                f"<tool_call>{json.dumps(tc)}</tool_call>"
+                for tc in response_content["tool_calls"]
+            )
+
+        content_text = (response_content["content"] or "") + tool_blocks
+
         assistant_message = AssistantMessage(
             role=response_content["role"],
-            content=[Text(text=response_content["content"])] if response_content["content"] else [],
+            content=[Text(text=content_text)] if content_text else [],
             tool_calls=response_content["tool_calls"],
         )
         if append_assistant_message:

--- a/src/proxy_lite/client.py
+++ b/src/proxy_lite/client.py
@@ -51,6 +51,7 @@ class BaseClient(BaseModel, ABC):
     @classmethod
     def create(cls, config: BaseClientConfig) -> "BaseClient":
         supported_clients = {
+            "openai": OpenAIClient,
             "openai-azure": OpenAIClient,
             "convergence": ConvergenceClient,
         }
@@ -72,7 +73,7 @@ class BaseClient(BaseModel, ABC):
 
 class OpenAIClientConfig(BaseClientConfig):
     name: Literal["openai"] = "openai"
-    model_id: str = "gpt-4o"
+    model_id: str = "gpt-4.1"
     api_key: str = os.environ.get("OPENAI_API_KEY")
 
 
@@ -103,8 +104,10 @@ class OpenAIClient(BaseClient):
         optional_params = {
             "seed": seed,
             "tools": self.serializer.serialize_tools(tools) if tools else None,
-            "tool_choice": "required" if tools else None,
-            "response_format": {"type": "json_object"} if response_format else {"type": "text"},
+            "tool_choice": "auto" if tools else None,
+            "response_format": (
+                {"type": "json_object"} if response_format else {"type": "text"}
+            ),
         }
         base_params.update({k: v for k, v in optional_params.items() if v is not None})
         return await self.external_client.chat.completions.create(**base_params)
@@ -125,11 +128,13 @@ class ConvergenceClient(OpenAIClient):
     async def _validate_model(self) -> None:
         try:
             response = await self.external_client.models.list()
-            assert self.config.model_id in [model.id for model in response.data], (
-                f"Model {self.config.model_id} not found in {response.data}"
-            )
+            assert self.config.model_id in [
+                model.id for model in response.data
+            ], f"Model {self.config.model_id} not found in {response.data}"
             self._model_validated = True
-            logger.debug(f"Model {self.config.model_id} validated and connected to cluster")
+            logger.debug(
+                f"Model {self.config.model_id} validated and connected to cluster"
+            )
         except Exception as e:
             logger.error(f"Error retrieving model: {e}")
             raise e
@@ -160,7 +165,9 @@ class ConvergenceClient(OpenAIClient):
         optional_params = {
             "seed": seed,
             "tools": self.serializer.serialize_tools(tools) if tools else None,
-            "tool_choice": "auto" if tools else None,  # vLLM does not support "required"
+            "tool_choice": (
+                "auto" if tools else None
+            ),  # vLLM does not support "required"
             "response_format": response_format if response_format else {"type": "text"},
         }
         base_params.update({k: v for k, v in optional_params.items() if v is not None})

--- a/src/proxy_lite/history.py
+++ b/src/proxy_lite/history.py
@@ -13,7 +13,6 @@ class MessageLabel(str, Enum):
     USER_INPUT = "user_input"
     SCREENSHOT = "screenshot"
     AGENT_MODEL_RESPONSE = "agent_model_response"
-    TOOL_RESPONSE = "tool_response"
 
 
 MAX_MESSAGES_FOR_CONTEXT_WINDOW = {

--- a/src/proxy_lite/history.py
+++ b/src/proxy_lite/history.py
@@ -13,6 +13,7 @@ class MessageLabel(str, Enum):
     USER_INPUT = "user_input"
     SCREENSHOT = "screenshot"
     AGENT_MODEL_RESPONSE = "agent_model_response"
+    TOOL_RESPONSE = "tool_response"
 
 
 MAX_MESSAGES_FOR_CONTEXT_WINDOW = {
@@ -74,7 +75,9 @@ class Message(BaseModel):
         if text is not None:
             text = Text(text=text)
         if image is not None:
-            base64_image = image if is_base64 else base64.b64encode(image).decode("utf-8")
+            base64_image = (
+                image if is_base64 else base64.b64encode(image).decode("utf-8")
+            )
             data_url = f"data:image/jpeg;base64,{base64_image}"
             image = Image(image_url=ImageUrl(url=data_url))
             content = [text, image] if text is not None else [image]

--- a/src/proxy_lite/serializer.py
+++ b/src/proxy_lite/serializer.py
@@ -35,5 +35,8 @@ class OpenAICompatibleSerializer(BaseSerializer):
         )
 
     def serialize_tools(self, tools: list[Tool]) -> list[dict]:
-        tool_schemas = [[{"type": "function", "function": schema} for schema in tool.schema] for tool in tools]
+        tool_schemas = [
+            [{"type": "function", "function": schema} for schema in tool.schema]
+            for tool in tools
+        ]
         return list(itertools.chain.from_iterable(tool_schemas))

--- a/src/proxy_lite/solvers/simple_solver.py
+++ b/src/proxy_lite/solvers/simple_solver.py
@@ -43,7 +43,8 @@ class SimpleSolver(BaseSolver):
     @property
     def history(self) -> MessageHistory:
         return MessageHistory(
-            messages=[SystemMessage.from_media(text=self.agent.system_prompt)] + self.agent.history.messages,
+            messages=[SystemMessage.from_media(text=self.agent.system_prompt)]
+            + self.agent.history.messages,
         )
 
     async def initialise(self, task: str, env_tools: list[Tool], env_info: str) -> None:
@@ -56,6 +57,14 @@ class SimpleSolver(BaseSolver):
         self.logger.debug(f"Initialised with task: {task}")
 
     async def act(self, observation: Observation) -> Action:
+        # If the previous env step contained tool responses, convert them
+        if observation.state.tool_responses:
+            for resp in observation.state.tool_responses:
+                self.agent.receive_tool_message(
+                    text=resp.content or "",
+                    tool_id=resp.id,
+                    label=MessageLabel.TOOL_RESPONSE,
+                )
         self.agent.receive_user_message(
             image=observation.state.image,
             text=observation.state.text,
@@ -68,7 +77,10 @@ class SimpleSolver(BaseSolver):
         self.logger.debug(f"Assistant message generated: {message}")
 
         # check tool calls for return_value
-        if any(tool_call.function["name"] == "return_value" for tool_call in message.tool_calls):
+        if any(
+            tool_call.function["name"] == "return_value"
+            for tool_call in message.tool_calls
+        ):
             self.complete = True
             arguments = json.loads(message.tool_calls[0].function["arguments"])
             if isinstance(arguments, str):
@@ -78,15 +90,23 @@ class SimpleSolver(BaseSolver):
 
         text_content = message.content[0].text
 
-        observation_match = re.search(r"<observation>(.*?)</observation>", text_content, re.DOTALL)
-        observation_content = observation_match.group(1).strip() if observation_match else ""
+        observation_match = re.search(
+            r"<observation>(.*?)</observation>", text_content, re.DOTALL
+        )
+        observation_content = (
+            observation_match.group(1).strip() if observation_match else ""
+        )
 
         self.logger.info("🌐 [bold blue]Observation:[/]")
         await self.logger.stream_message(observation_content)
 
         # Extract text between thinking tags if present
-        thinking_match = re.search(r"<thinking>(.*?)</thinking>", text_content, re.DOTALL)
-        thinking_content = thinking_match.group(1).strip() if thinking_match else text_content
+        thinking_match = re.search(
+            r"<thinking>(.*?)</thinking>", text_content, re.DOTALL
+        )
+        thinking_content = (
+            thinking_match.group(1).strip() if thinking_match else text_content
+        )
 
         self.logger.info("🧠 [bold purple]Thinking:[/]")
         await self.logger.stream_message(thinking_content)

--- a/src/proxy_lite/solvers/simple_solver.py
+++ b/src/proxy_lite/solvers/simple_solver.py
@@ -60,10 +60,9 @@ class SimpleSolver(BaseSolver):
         # If the previous env step contained tool responses, convert them
         if observation.state.tool_responses:
             for resp in observation.state.tool_responses:
-                self.agent.receive_tool_message(
+                await self.agent.receive_tool_message(
                     text=resp.content or "",
                     tool_id=resp.id,
-                    label=MessageLabel.TOOL_RESPONSE,
                 )
         self.agent.receive_user_message(
             image=observation.state.image,


### PR DESCRIPTION
What's added:
- recognise "openai" in client factory
- send tools as `{type:"function", function:{…}}`
- re-inject `<tool_call>{…}</tool_call>` into content for legacy parser
- auto-append matching `role:"tool"` messages after each execution
- default model → `gpt-4.1`, `tool_choice="auto"`

Fixes the 400 error “tool_calls must be followed by tool messages” and keeps old models/vLLM working unchanged.